### PR TITLE
Compatible with Texture 2.7

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - GTTexture-RxExtension (1.1.0):
+  - GTTexture-RxExtension (1.2.0):
     - RxCocoa (~> 4.0)
     - RxSwift (~> 4.0)
     - Texture (~> 2.6)
@@ -25,10 +25,10 @@ PODS:
   - RxSwift (4.1.2)
   - RxTest (4.1.2):
     - RxSwift (~> 4.0)
-  - Texture (2.6):
-    - Texture/PINRemoteImage (= 2.6)
-  - Texture/Core (2.6)
-  - Texture/PINRemoteImage (2.6):
+  - Texture (2.7):
+    - Texture/PINRemoteImage (= 2.7)
+  - Texture/Core (2.7)
+  - Texture/PINRemoteImage (2.7):
     - PINRemoteImage/iOS (= 3.0.0-beta.13)
     - PINRemoteImage/PINCache
     - Texture/Core
@@ -39,12 +39,24 @@ DEPENDENCIES:
   - Quick
   - RxTest (~> 4.0)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Nimble
+    - PINCache
+    - PINOperation
+    - PINRemoteImage
+    - Quick
+    - RxCocoa
+    - RxSwift
+    - RxTest
+    - Texture
+
 EXTERNAL SOURCES:
   GTTexture-RxExtension:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  GTTexture-RxExtension: bed0f570903eff679808b491698aa4ea1b8f0de1
+  GTTexture-RxExtension: f9922bb5b6ef2a6b16699d78dad85849f93caea6
   Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
   PINCache: d195fdba255283f7e9900a55e3cced377f431f9b
   PINOperation: a6219e6fc9db9c269eb7a7b871ac193bcf400aac
@@ -53,8 +65,8 @@ SPEC CHECKSUMS:
   RxCocoa: d88ba0f1f6abf040011a9eb4b539324fc426843a
   RxSwift: e49536837d9901277638493ea537394d4b55f570
   RxTest: e634f15fd2c2cd0e0120132ef7a4f7be69ad0393
-  Texture: 7249074582daf75e524e59df5428b66b8e8db0e4
+  Texture: 9d7e38965cf22ccd7cd9c249dd78b3f14e70ab6c
 
 PODFILE CHECKSUM: 68115f24e3cc3827d8759c972f6629a1789cec41
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.5.3

--- a/GTTexture-RxExtension/Classes/ASButtonNode+RxExtension.swift
+++ b/GTTexture-RxExtension/Classes/ASButtonNode+RxExtension.swift
@@ -199,11 +199,11 @@ extension Reactive where Base: ASButtonNode {
                                url: URL,
                                target: ImageDownloadTarget,
                                state: UIControlState?) {
-        ASPINRemoteImageDownloader.shared()
+        ASPINRemoteImageDownloader.shared
             .downloadImage(with: url,
                            callbackQueue: DispatchQueue.global(qos: .background),
                            downloadProgress: nil,
-                           completion: { image, err, id in
+                           completion: { image, err, id, userInfo in
                             switch target {
                             case .image:
                                 if let state = state {


### PR DESCRIPTION
Texture 2.7 changed `ASImageDownloaderCompletion` to `(id <ASImageContainerProtocol> _Nullable image, NSError * _Nullable error, id _Nullable downloadIdentifier, id _Nullable userInfo)`, and changed `ASPINRemoteImageDownloader.shared()` to a property `ASPINRemoteImageDownloader.shared`.